### PR TITLE
Optimize unknown alpha paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,7 @@
 name: Lint & Test
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [ opened, edited, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,11 +11,11 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,54 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
+All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.4.0] - 2023-12-29
+## [0.5.0] - 2025-06-22
+
 ### Changed
+
+- Updated deps.
+- Updated CI config.
+- Updated documentation.
+- Optimized parsing performance for unknown alpha paths by pre-looking date part lookup prior to parsing.
+
+## [0.4.0] - 2023-12-29
+
+### Changed
+
 - Updated deps.
 - Updated CI config.
 - Update + Add documentation.
 - Add addition supported date format `%A %B %e %Y` (e.g. `Sunday, April 18th, 2021`).
 
 ## [0.3.0] - 2021-11-14
+
 ### Added
+
 - Serde deserialize_with helper functions.
 - Examples directory
 
 ## [0.2.0] - 2021-11-09
+
 ### Changed
+
 - Fixed Cargo.toml categories
 
 ## [0.1.0] - 2021-11-09
+
 ### Added
+
 - Initial Release
 
 [Unreleased]: https://github.com/rust-playground/anydate/compare/v0.4.0...HEAD
+
 [0.4.0]: https://github.com/rust-playground/anydate/compare/v0.3.0...v0.4.0
+
 [0.3.0]: https://github.com/rust-playground/anydate/compare/v0.2.0...v0.3.0
+
 [0.2.0]: https://github.com/rust-playground/anydate/compare/v0.1.0...v0.2.0
+
 [0.1.0]: https://github.com/rust-playground/anydate/commit/4ac9022aeeb9d2911a763651f70987cb8d98d47d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated deps.
 - Updated CI config.
 - Updated documentation.
+- Updated to Rust 2024 edition.
 - Optimized parsing performance for unknown alpha paths by pre-looking date part lookup prior to parsing.
 
 ## [0.4.0] - 2023-12-29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "anydate"
 description = "Date & DateTime string parser"
-version = "0.4.0"
-edition = "2021"
+version = "0.5.0"
+edition = "2024"
 authors = ["Dean Karn <dean.karn@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,12 +19,12 @@ harness = false
 name = "bench"
 
 [dependencies]
-chrono = { version = "0.4.31", default-features = false, features = ["std"] }
-serde = {version = "1.0.192", features = ["derive"], optional = true }
-thiserror = "1.0.50"
+chrono = { version = "0.4.40", default-features = false, features = ["std"] }
+serde = { version = "1.0.218", features = ["derive"], optional = true }
+thiserror = "2.0.11"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = { version = "0.6.0", features = ["html_reports"] }
 serde_json = "1.0.108"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # anydate &emsp; [![Latest Version]][crates.io]
 
 [Latest Version]: https://img.shields.io/crates/v/anydate.svg
+
 [crates.io]: https://crates.io/crates/anydate
 
 This crate is used to parse an unknown DateTime or Date format into a normalized version.
@@ -11,9 +12,10 @@ Any significant changes to anydate are documented in
 the [`CHANGELOG.md`](https://github.com/rust-playground/anydate/blob/main/CHANGELOG.md) file.
 
 ## Usage
+
 ```toml
 [dependencies]
-anydate = "0.4"
+anydate = "0.5"
 ```
 
 ### Features
@@ -25,6 +27,7 @@ Optional features:
 [`serde`]: https://github.com/serde-rs/serde
 
 ### Example usages
+
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // see parse_utc() for convenience conversion to UTC

--- a/src/date.rs
+++ b/src/date.rs
@@ -30,20 +30,33 @@ pub(crate) fn parse_with_alpha(s: &str) -> Result<NaiveDate, Error> {
 
 fn parse_naive_dates(s: &str) -> Result<NaiveDate, Error> {
     // Date parse formats
-    const PARSE_FORMATS: &[&str] = &[
-        "%Y-%m-%d",
-        "%Y/%m/%d",
-        "%Y.%m.%d",
-        "%m/%d/%y",
-        "%m/%d/%Y",
-        "%m.%d.%y",
-        "%m.%d.%Y",
-        "%Y-%b-%d",
-        "%d %B %y",
-        "%d %B %Y",
-        "%Y年%m月%d日",
-    ];
-    PARSE_FORMATS
+    const PARSE_FORMATS_DASHES: &[&str] = &["%Y-%m-%d", "%Y-%b-%d"];
+
+    const PARSE_FORMATS_SLASHES: &[&str] = &["%Y/%m/%d", "%m/%d/%y", "%m/%d/%Y"];
+
+    const PARSE_FORMATS_DOT: &[&str] = &["%Y.%m.%d", "%m.%d.%y", "%m.%d.%Y"];
+
+    const PARSE_FORMATS_SPACE: &[&str] = &["%d %B %y", "%d %B %Y"];
+
+    const PARSE_FORMATS_REMAINING: &[&str] = &["%Y年%m月%d日"];
+
+    for c in s.chars() {
+        if !c.is_alphanumeric() {
+            return match c {
+                '-' => PARSE_FORMATS_DASHES,
+                '/' => PARSE_FORMATS_SLASHES,
+                '.' => PARSE_FORMATS_DOT,
+                ' ' => PARSE_FORMATS_SPACE,
+                _ => break,
+            }
+            .iter()
+            .map(|fmt| NaiveDate::parse_from_str(s, fmt))
+            .find_map(Result::ok)
+            .map_or_else(|| Err(Error::InvalidDate), Ok);
+        }
+    }
+
+    PARSE_FORMATS_REMAINING
         .iter()
         .map(|fmt| NaiveDate::parse_from_str(s, fmt))
         .find_map(Result::ok)
@@ -114,6 +127,7 @@ mod tests {
                 *expected,
                 parse(input)?
                     .and_time(NaiveTime::from_num_seconds_from_midnight_opt(0, 0).unwrap())
+                    .and_utc()
                     .timestamp_nanos_opt()
                     .unwrap()
             );

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -138,31 +138,48 @@ fn parse_naive_datetime(s: &str) -> Result<DateTime<FixedOffset>, Error> {
 
 fn parse_utc_naive_datetime_unknown_alpha(s: &str) -> Result<DateTime<FixedOffset>, Error> {
     // DateTimes without timezone info
-    const PARSE_FORMATS: &[&str] = &[
+    const PARSE_FORMATS_DASHES: &[&str] = &[
         "%Y-%m-%d %H:%M:%S%.f",
         "%Y-%m-%d %H:%M:%S",
         "%Y-%m-%d %H:%M",
+        "%Y-%m-%d %I:%M:%S %P",
+        "%Y-%m-%d %I:%M %P",
+    ];
+
+    const PARSE_FORMATS_SLASHES: &[&str] = &[
         "%m/%d/%y %H:%M:%S",
         "%m/%d/%y %H:%M",
         "%m/%d/%y %H:%M:%S%.f",
         "%m/%d/%Y %H:%M:%S",
         "%m/%d/%Y %H:%M",
         "%m/%d/%Y %H:%M:%S%.f",
-        "%y%m%d %H:%M:%S",
         "%Y/%m/%d %H:%M:%S",
         "%Y/%m/%d %H:%M",
         "%Y/%m/%d %H:%M:%S%.f",
-        "%Y-%m-%d %I:%M:%S %P",
-        "%Y-%m-%d %I:%M %P",
         "%m/%d/%y %I:%M:%S %P",
         "%m/%d/%y %I:%M %P",
         "%m/%d/%Y %I:%M:%S %P",
         "%m/%d/%Y %I:%M %P",
         "%Y/%m/%d %I:%M:%S %P",
         "%Y/%m/%d %I:%M %P",
-        "%Y年%m月%d日%H时%M分%S秒",
     ];
-    parse_utc_naive_datetime(s, PARSE_FORMATS)
+
+    const PARSE_FORMATS_REMAINING: &[&str] = &["%y%m%d %H:%M:%S", "%Y年%m月%d日%H时%M分%S秒"];
+
+    for c in s.chars() {
+        if !c.is_alphanumeric() {
+            return parse_utc_naive_datetime(
+                s,
+                match c {
+                    '-' => PARSE_FORMATS_DASHES,
+                    '/' => PARSE_FORMATS_SLASHES,
+                    _ => break,
+                },
+            );
+        }
+    }
+
+    parse_utc_naive_datetime(s, PARSE_FORMATS_REMAINING)
 }
 
 fn parse_utc_naive_datetime_alpha_prefix(s: &str) -> Result<DateTime<FixedOffset>, Error> {
@@ -211,9 +228,9 @@ fn parse_utc_naive_datetime(s: &str, formats: &[&str]) -> Result<DateTime<FixedO
         )
 }
 
-// last ditch effort, timezone abbreviation can't 100% relied upon.
+// last ditch effort, timezone abbreviation can't 100% be relied upon.
 //
-// It is not possible to reliably convert from an abbreviation to an offset, for example CDT can
+// It is not possible to reliably convert from an abbreviation to an offset; for example, CDT can
 // mean either Central Daylight Time (North America) or China Daylight Time.
 //
 // list sourced from https://www.utctime.net/time-zone-abbreviations
@@ -231,9 +248,9 @@ fn parse_timezone_abbreviation_unknown_alpha(s: &str) -> Result<DateTime<FixedOf
     )
 }
 
-// last ditch effort, timezone abbreviation can't 100% relied upon.
+// last ditch effort, timezone abbreviation can't 100% be relied upon.
 //
-// It is not possible to reliably convert from an abbreviation to an offset, for example CDT can
+// It is not possible to reliably convert from an abbreviation to an offset; for example, CDT can
 // mean either Central Daylight Time (North America) or China Daylight Time.
 //
 // list sourced from https://www.utctime.net/time-zone-abbreviations

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -40,7 +40,7 @@ pub mod deserialize {
     //! println!("{:?}", dt);
     //!
     //! ```
-    use super::{de, AnydateVisitor, DateTime, FixedOffset, Utc};
+    use super::{AnydateVisitor, DateTime, FixedOffset, Utc, de};
 
     /// deserializes to a [`DateTime<FixedOffset>`]
     ///
@@ -143,7 +143,7 @@ pub mod deserialize {
                     None => {
                         assert_eq!(s.dt, None);
                     }
-                };
+                }
             }
             Ok(())
         }
@@ -197,7 +197,7 @@ pub mod deserialize {
                     None => {
                         assert_eq!(s.dt, None);
                     }
-                };
+                }
             }
             Ok(())
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -5,7 +5,7 @@ use serde::de;
 
 struct AnydateVisitor;
 
-impl<'de> de::Visitor<'de> for AnydateVisitor {
+impl de::Visitor<'_> for AnydateVisitor {
     type Value = DateTime<FixedOffset>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
optimizations of some code paths.

```terminal
datetime/rfc3339_nano   time:   [37.431 ns 37.597 ns 38.258 ns]
                        change: [−4.7814% −3.5662% −2.3576%] (p = 0.05 > 0.05)
                        No change in performance detected.
datetime/rfc2822        time:   [58.006 ns 58.333 ns 59.638 ns]
                        change: [+0.0819% +1.6816% +3.2823%] (p = 0.22 > 0.05)
                        No change in performance detected.
datetime/yyyy-mm-dd hh:mm:ss
                        time:   [726.00 ns 728.12 ns 736.59 ns]
                        change: [+0.0474% +1.0165% +1.9704%] (p = 0.18 > 0.05)
                        No change in performance detected.
datetime/yyyy-mm-dd hh:mm:ss z
                        time:   [129.03 ns 130.16 ns 134.65 ns]
                        change: [+0.2906% +2.7469% +5.1737%] (p = 0.12 > 0.05)
                        No change in performance detected.
datetime/yyyy-mm-dd     time:   [915.05 ns 923.76 ns 958.61 ns]
                        change: [−23.202% −21.216% −19.241%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/yyyy-mon-dd    time:   [569.88 ns 573.40 ns 587.45 ns]
                        change: [−34.997% −33.893% −32.786%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/Mon dd, yyyy, hh:mm:ss
                        time:   [477.14 ns 480.01 ns 491.51 ns]
                        change: [+1.1712% +2.8519% +4.5495%] (p = 0.19 > 0.05)
                        No change in performance detected.
datetime/Sunday, April 18th, 2021
                        time:   [436.97 ns 439.74 ns 440.43 ns]
                        change: [+3.9001% +4.4618% +5.0200%] (p = 0.01 < 0.05)
                        Performance has regressed.
datetime/dd Mon yyyy hh:mm:ss
                        time:   [579.22 ns 583.31 ns 599.69 ns]
                        change: [−37.141% −35.904% −34.674%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/dd Mon yyyy    time:   [679.00 ns 684.05 ns 704.22 ns]
                        change: [−39.170% −37.919% −36.679%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/mm/dd/yyyy hh:mm:ss
                        time:   [1.1907 µs 1.1908 µs 1.1910 µs]
                        change: [−10.433% −10.226% −10.053%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/mm/dd/yyyy     time:   [1.3704 µs 1.3841 µs 1.4391 µs]
                        change: [−11.974% −9.6361% −7.2861%] (p = 0.03 < 0.05)
                        Performance has improved.
datetime/yyyy/mm/dd hh:mm:ss
                        time:   [337.61 ns 339.22 ns 345.62 ns]
                        change: [−21.510% −20.405% −19.309%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/yyyy/mm/dd     time:   [880.28 ns 881.11 ns 881.32 ns]
                        change: [−13.312% −13.061% −12.800%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/mm.dd.yyyy     time:   [511.35 ns 511.74 ns 513.29 ns]
                        change: [−46.052% −45.785% −45.540%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/yyyy.mm.dd     time:   [421.16 ns 421.19 ns 421.34 ns]
                        change: [−45.099% −44.981% −44.872%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/yymmdd hh:mm:ss
                        time:   [243.71 ns 244.31 ns 246.69 ns]
                        change: [−34.537% −33.993% −33.435%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/chinese yyyy mm dd hh mm ss
                        time:   [327.95 ns 328.02 ns 328.29 ns]
                        change: [−48.614% −48.471% −48.330%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/chinese yyyy mm dd
                        time:   [521.48 ns 523.39 ns 531.01 ns]
                        change: [−48.830% −48.254% −47.687%] (p = 0.00 < 0.05)
                        Performance has improved.
datetime/timezone_abbrev
                        time:   [1.6142 µs 1.6160 µs 1.6231 µs]
                        change: [−19.545% −19.214% −18.886%] (p = 0.00 < 0.05)
                        Performance has improved.
```